### PR TITLE
ci: use GitHub App installation token for checkout and push in releas…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,38 +80,51 @@ jobs:
       run: |
         make down
 
-  release:
-    name: Semantic Release
-    needs: test-and-lint
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+release:
+  name: Semantic Release
+  needs: test-and-lint
+  runs-on: ubuntu-latest
+  if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  permissions:
+    contents: write
+    issues: write
+    pull-requests: write
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "lts/*"
+  steps:
+    - name: Create GitHub App installation token
+      id: app-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
 
-      - name: Install semantic-release and plugins
-        run: |
-          npm install -g semantic-release \
-            @semantic-release/commit-analyzer \
-            @semantic-release/release-notes-generator \
-            @semantic-release/changelog \
-            @semantic-release/git \
-            @semantic-release/github
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        token: ${{ steps.app-token.outputs.token }}
 
-      - name: Run semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+    - name: Configure Git user
+      run: |
+        git config user.name  "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "lts/*"
+
+    - name: Install semantic-release and plugins
+      run: |
+        npm install -g semantic-release \
+          @semantic-release/commit-analyzer \
+          @semantic-release/release-notes-generator \
+          @semantic-release/changelog \
+          @semantic-release/git \
+          @semantic-release/github
+
+    - name: Run semantic-release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npx semantic-release


### PR DESCRIPTION
Overview
This draft PR updates the release workflow so that, instead of relying solely on GITHUB_TOKEN, it generates and uses a GitHub App installation token for the checkout and push steps on the protected main branch. This ensures our semantic-release bot can bypass the “Restrict updates” rule without exposing a PAT.

Key Changes

Create GitHub App token: Added a step using actions/create-github-app-token@v1 with our App’s ID and private key.

Checkout with App token: Switched actions/checkout to use the App token (persist-credentials: false, token: ${{ steps.app-token.outputs.token }}).

Git user configuration: Configures commits from the bot as github-actions[bot].

Separation of concerns: Retains GITHUB_TOKEN for creating GitHub Releases while the App token handles file pushes.

Why

Allows semantic-release to push changelog and version bumps directly to main without disabling branch protections or using a personal access token.

Restricts bypass privileges exclusively to our GitHub App (“CI Release Bot”), keeping human and other workflows subject to PR reviews and status checks.

Testing Plan

Merge a trivial change via PR into main → confirm the release job runs successfully.

Verify that a commit updating CHANGELOG.md (and version bump) appears, authored by github-actions[bot].

Attempt a direct push to main with a normal token → confirm it’s blocked by branch protection.

Confirm that our GitHub App token can still push to main and update files.