### PR TITLE
ci: use GitHub App installation token for checkout and push in release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.3.0](https://github.com/rad-solutions/webserver/compare/v1.2.0...v1.3.0) (2025-05-15)
+
+
+### Features
+
+* Integrate Poetry ([7988053](https://github.com/rad-solutions/webserver/commit/7988053e01182a7e631f1cf42346964bfa2b7628))
+
 # [1.2.0](https://github.com/rad-solutions/webserver/compare/v1.1.0...v1.2.0) (2025-05-12)
 
 


### PR DESCRIPTION
Overview
This draft PR updates the release workflow so that, instead of relying solely on GITHUB_TOKEN, it generates and uses a GitHub App installation token for the checkout and push steps on the protected main branch. This ensures our semantic-release bot can bypass the “Restrict updates” rule without exposing a PAT.

Key Changes

Create GitHub App token: Added a step using actions/create-github-app-token@v1 with our App’s ID and private key.

Checkout with App token: Switched actions/checkout to use the App token (persist-credentials: false, token: ${{ steps.app-token.outputs.token }}).

Git user configuration: Configures commits from the bot as github-actions[bot].

Separation of concerns: Retains GITHUB_TOKEN for creating GitHub Releases while the App token handles file pushes.

Why

Allows semantic-release to push changelog and version bumps directly to main without disabling branch protections or using a personal access token.

Restricts bypass privileges exclusively to our GitHub App (“CI Release Bot”), keeping human and other workflows subject to PR reviews and status checks.

Testing Plan

Merge a trivial change via PR into main → confirm the release job runs successfully.

Verify that a commit updating CHANGELOG.md (and version bump) appears, authored by github-actions[bot].

Attempt a direct push to main with a normal token → confirm it’s blocked by branch protection.

Confirm that our GitHub App token can still push to main and update files.