### PR TITLE
Feat/UI XRayTube and History Managment

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -8,6 +8,7 @@ from app.views import (
     EquiposDetailView,
     EquiposListView,
     EquiposUpdateView,
+    EquipoTuboUpdateView,
     ProcessCreateView,
     ProcessDeleteView,
     ProcessDetailView,
@@ -82,6 +83,11 @@ urlpatterns = [
     ),
     path(
         "equipos/<int:pk>/delete/", EquiposDeleteView.as_view(), name="equipos_delete"
+    ),
+    path(
+        "equipos/<int:pk>/tubo/update/",
+        EquipoTuboUpdateView.as_view(),
+        name="tubo_update",
     ),
     path(
         "ajax/load-user-processes/",

--- a/templates/equipos/equipos_detail.html
+++ b/templates/equipos/equipos_detail.html
@@ -28,6 +28,20 @@
                 <div class="col-md-4"><strong>Serial:</strong></div>
                 <div class="col-md-8">{{ equipo.serial }}</div>
             </div>
+            {% with tubo=equipo.get_current_xray_tube %}
+                <div class="row mb-3">
+                    <div class="col-md-4"><strong>Marca Tubo:</strong></div>
+                    <div class="col-md-8">{{ tubo.marca }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4"><strong>Modelo Tubo:</strong></div>
+                    <div class="col-md-8">{{ tubo.modelo }}</div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-md-4"><strong>Serial Tubo:</strong></div>
+                    <div class="col-md-8">{{ tubo.serial }}</div>
+                </div>
+            {% endwith %}
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Practica Asociada:</strong></div>
                 <div class="col-md-8">{{ equipo.practica_asociada }}</div>
@@ -132,6 +146,29 @@
                 {% endif %}
             {% endif %}
         </div>
+    </div>
+    <br>
+    <div class="card">
+        <div class="card-header">
+            <h3>Historial Tubo de Rayos X</h3>
+        </div>
+        <div class="card-body">
+            {% if equipo.historial_tubos_rayos_x %}
+            <ul class="list-group">
+                {% for tubo in equipo.historial_tubos_rayos_x.all %}
+                <li class="list-group-item">
+                    Marca del Tubo: {{ tubo.marca }} - Modelo del Tubo: {{ tubo.modelo }} <br> (Serial del tubo: {{ tubo.serial }})
+                    <br>
+                    <small class="text-muted">{{ tubo.fecha_cambio|date:"d/m/Y" }}</small>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </div>
+        <div class="card-footer">
+            {% if perms.app.manage_equipment %}
+                <a href="{% url 'tubo_update' pk=equipo.id %}" class="btn btn-primary">Actualizar Tubo Rayos X</a>
+            {% endif %}
     </div>
 </div>
 {% endblock %}

--- a/templates/equipos/tubo_xray_form.html
+++ b/templates/equipos/tubo_xray_form.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+
+{% block title %}
+    Agregar Datos de Tubo de Rayos X
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="card">
+        <div class="card-header">
+            <h2>Agregar Datos de Tubo de Rayos X</h2>
+        </div>
+        <div class="card-body">
+            <form method="post" enctype="multipart/form-data">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <div class="mt-3">
+                    <button type="submit" class="btn btn-success">Guardar</button>
+                    <a href="javascript:window.history.back();" class="btn btn-secondary">Cancelar</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## PR Description: XRay Tube and History Managment
This pull request introduces functionality to manage the history of X-ray tubes associated with equipment. It includes updates to models, views, templates, and tests to support adding, updating, and displaying X-ray tube data. The most important changes are grouped into themes below.

### Model and Form Updates:
* Added `HistorialTuboRayosX` to the imports in `app/tests/test_equipment.py` and `app/views.py` to handle X-ray tube history. [[1]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25R10) [[2]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR29)
* Created `HistorialTuboRayosXForm` in `app/views.py` to provide a form for managing X-ray tube data.

### View Enhancements:
* Added `EquipoTuboUpdateView` in `app/views.py` to enable updates to X-ray tube information for equipment.
* Modified `EquiposCreateView` to redirect to the X-ray tube update form upon successful equipment creation.

### URL Updates:
* Added a new route in `app/urls.py` for updating X-ray tube data (`tubo_update`).

### Template Updates:
* Enhanced `templates/equipos/equipos_detail.html` to display current X-ray tube details and the history of X-ray tubes in a card layout. Added a button for updating tube data if the user has permissions. [[1]](diffhunk://#diff-eea4121866b3679293ddc9eb737f2d0f394f78b8770e64ca5b2acdde3b884c8bR31-R44) [[2]](diffhunk://#diff-eea4121866b3679293ddc9eb737f2d0f394f78b8770e64ca5b2acdde3b884c8bR150-R172)
* Created `templates/equipos/tubo_xray_form.html` for the X-ray tube update form.

### Test Coverage:
* Added `XRayTubeHistoryTest` in `app/tests/test_equipment.py` to ensure functionality for displaying tube history, registering new tubes, and retrieving the current tube works as expected.