### PR TITLE
feat: Actualizar script populate_db y configuración de Docker

### DIFF
--- a/app/management/commands/populate_db.py
+++ b/app/management/commands/populate_db.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         User.objects.filter(is_superuser=False).exclude(
             username__in=predefined_usernames
         ).delete()
-        Role.objects.all().delete()
+        # Role.objects.all().delete() # This was deleting all roles and causing test users to lose their roles.
         # ClientProfile, Process, Equipment, Report, Anotacion will cascade delete
         # or be deleted if their User/Process is deleted.
 
@@ -147,10 +147,16 @@ class Command(BaseCommand):
                         0
                     ]
 
+                # Assign the process to a random internal staff member
+                assigned_user = None
+                if internal_staff_users:
+                    assigned_user = random.choice(internal_staff_users)
+
                 process = Process.objects.create(
                     user=user_obj,
                     process_type=process_type,
                     practice_category=practice_category,
+                    assigned_to=assigned_user,  # Assign internal staff
                     estado=random.choice(ProcessStatusChoices.choices)[0],
                     fecha_final=(
                         fake.date_time_this_decade(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   web:
+    # Para construir la imagen localmente usando el Dockerfile,
+    # comenta la siguiente línea 'image' y descomenta la línea 'build'.
     image: 978368259161.dkr.ecr.us-east-1.amazonaws.com/webserver:latest
+    # build: .
     container_name: radsolutions_web
     command: gunicorn --bind 0.0.0.0:8000 app_server.wsgi:application
     ports:


### PR DESCRIPTION
Problemas Solucionados
Pérdida de roles de usuario: Al ejecutar manage.py populate_db, los usuarios de prueba creados con manage.py create_users perdían sus roles asignados. Esto se debía a que el script eliminaba todos los roles existentes.
Campos incompletos en la población: El script no asignaba valores a ciertos campos de relación importantes, como el campo assigned_to en el modelo Process.