### PR TITLE
Feat/Fix Saving Process Report

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1079,19 +1079,16 @@ class ReportCreateView(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
         return PermissionRequiredMixin.handle_no_permission(self)
 
     def form_valid(self, form):
-        try:
-            response = super().form_valid(form)
-            # Verificar si el archivo se guardó correctamente
-            if hasattr(form.instance, "pdf_file") and form.instance.pdf_file:
-                logger.info(
-                    f"Archivo guardado exitosamente: {form.instance.pdf_file.name}"
-                )
-                logger.info(f"URL del archivo: {form.instance.pdf_file.url}")
-            return response
-        except Exception as e:
-            logger.error(f"Error al guardar el reporte: {str(e)}")
-            form.add_error(None, f"Error al guardar el reporte: {str(e)}")
-            return self.form_invalid(form)
+        # Guardar la instancia sin hacer commit a la BD para poder modificarla
+        self.object = form.save(commit=False)
+
+        # Llamar al método save() del modelo, pasando el usuario que modifica
+        self.object.save(user_who_modified=self.request.user)
+
+        logger.info(f"Archivo guardado exitosamente: {self.object.pdf_file.name}")
+        logger.info(f"URL del archivo: {self.object.pdf_file.url}")
+
+        return redirect(self.get_success_url())
 
 
 class ReportUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
@@ -1113,6 +1110,12 @@ class ReportUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
         # User is authenticated, but lacks permission.
         # Delegate to PermissionRequiredMixin's original behavior.
         return PermissionRequiredMixin.handle_no_permission(self)
+
+    def form_valid(self, form):
+        self.object = form.save(commit=False)
+        # Llamar al método save() del modelo, pasando el usuario que modifica
+        self.object.save(user_who_modified=self.request.user)
+        return redirect(self.get_success_url())
 
 
 class ReportDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
@@ -1757,11 +1760,13 @@ class ProcessCreateView(LoginRequiredMixin, CreateView):
 
     def form_valid(self, form):
         try:
-            response = super().form_valid(form)
+            self.object = form.save(commit=False)
+            # Llamar al método save() del modelo, pasando el usuario que modifica
+            self.object.save(user_who_modified=self.request.user)
             logger.info(
-                f"Proceso '{form.instance.process_type}' creado exitosamente por {self.request.user} con ID {form.instance.id}."
+                f"Proceso '{self.object.process_type}' creado exitosamente por {self.request.user} con ID {self.object.id}."
             )
-            return response
+            return redirect(self.get_success_url())
         except Exception as e:
             logger.error(
                 f"Error crítico al guardar el proceso para el usuario {self.request.user}: {str(e)}"
@@ -1798,6 +1803,12 @@ class ProcessUpdateView(LoginRequiredMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context["ProcessTypeChoices"] = ProcessTypeChoices
         return context
+
+    def form_valid(self, form):
+        self.object = form.save(commit=False)
+        # Llamar al método save() del modelo, pasando el usuario que modifica
+        self.object.save(user_who_modified=self.request.user)
+        return redirect(self.get_success_url())
 
 
 class ProcessUpdateAssignmentView(
@@ -1858,7 +1869,8 @@ class ProcessProgressUpdateView(LoginRequiredMixin, UpdateView):
         if form.is_valid() and (
             not self.object.checklist_items.exists() or checklist_formset.is_valid()
         ):
-            form.save()
+            process_instance = form.save(commit=False)
+            process_instance.save(user_who_modified=request.user)
             if self.object.checklist_items.exists():
                 checklist_items = checklist_formset.save(commit=False)
                 for item in checklist_items:


### PR DESCRIPTION
## PR Description: Feat Fix Saving Process Report.

This pull request refactors several `form_valid` methods across multiple views in `app/views.py` to improve handling of model saving and user tracking. The changes ensure that the user who modifies or creates an object is explicitly passed to the model's `save` method, enhancing auditability and consistency. Additionally, redundant exception handling and logging logic are simplified.

### Refactoring for improved user tracking and model saving:

* **`ReportCreateView` and `ReportUpdateView`:** Updated the `form_valid` method to save the model instance without committing, pass the modifying user to the `save` method so that is properly saved in the DB, and redirect to the success URL. Removed the previous exception handling and logging logic. [[1]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aL1082-R1091) [[2]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR1114-R1119)

* **`ProcessCreateView` and `ProcessUpdateView`:** Refactored the `form_valid` method to include similar changes as above, ensuring the modifying user is passed to the model's `save` method and simplifying the logging of successful operations. [[1]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aL1760-R1769) [[2]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR1807-R1812)

* **`ProcessUpdateAssignmentView`:** Adjusted the `post` method to save the process instance without committing and pass the modifying user explicitly to the `save` method.