### PR TITLE
Fix: Update ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS for App Runner 2

### DIFF
--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -23,7 +23,7 @@ CSRF_TRUSTED_ORIGINS = [
     "https://*.ngrok-free.app",
     "http://*.ngrok-free.app",
     "http://localhost",
-    "https://93xbj3r6wi.us-east-1.awsapprunner.com",
+    APP_RUNNER_URL,
 ]
 
 # Application definition


### PR DESCRIPTION
Added APP_RUNNER_URL on CSRF_TRUSTED_ORIGINS to use the same AWS_APP_RUNNER_URL_HOST env variable for both