### PR TITLE
feat: Implement dynamic host configuration for deployments

### DIFF
--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -23,7 +23,7 @@ CSRF_TRUSTED_ORIGINS = [
     "https://*.ngrok-free.app",
     "http://*.ngrok-free.app",
     "http://localhost",
-    "https://93xbj3r6wi.us-east-1.awsapprunner.com",
+    APP_RUNNER_URL,
 ]
 
 # Application definition


### PR DESCRIPTION
Problem:
After deploying to AWS App Runner, the application was inaccessible due to a CSRF verification failed error. This was because the automatically generated App Runner URL was not included in Django's CSRF_TRUSTED_ORIGINS.

Solution:
This PR introduces a more flexible configuration to support deployments.

A new environment variable, AWS_APP_RUNNER_URL_HOST, has been introduced.

settings.py has been updated to read this variable and dynamically add the corresponding URL to ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS.

Impact:
This change makes the application compatible with App Runner and avoids hardcoding URLs. The new environment variable must be configured in the App Runner service console.