### PR TITLE
Feat/Change Labels Forms

### DIFF
--- a/app/tests/test_equipment.py
+++ b/app/tests/test_equipment.py
@@ -412,6 +412,20 @@ class EquipmentAPITest(TestCase):
         self.assertNotIn(self.eq3, equipos_en_contexto)  # Pertenece a admin_user
         self.assertEqual(response.context["text_search_term"], "ModeloX100")
 
+    def test_equipment_create_view_shows_correct_labels(self):
+        """Verifica que el formulario de creación de equipos muestra las etiquetas en español."""
+        self.client.login(
+            username="admin_user", password="password"
+        )  # Usar un usuario con permisos
+        url = reverse("equipos_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verificar algunas de las nuevas etiquetas
+        self.assertContains(response, "Nombre del Equipo")
+        self.assertContains(response, "Práctica Asociada")
+        self.assertContains(response, "Cliente Propietario")
+
 
 class XRayTubeHistoryTest(TestCase):
     def setUp(self):

--- a/app/tests/test_process.py
+++ b/app/tests/test_process.py
@@ -742,6 +742,20 @@ class ProcessAPITest(TestCase):
             match_item2, "No se encontró el guion para el ítem 2 incompleto."
         )
 
+    def test_process_create_view_shows_correct_labels(self):
+        """Verifica que el formulario de creación de procesos muestra las etiquetas en español."""
+        self.client.login(
+            username="admin_proc", password="password"
+        )  # Usar un usuario con permisos
+        url = reverse("process_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verificar algunas de las nuevas etiquetas
+        self.assertContains(response, "Tipo de Proceso")
+        self.assertContains(response, "Cliente")
+        self.assertContains(response, "Fecha de Finalización")
+
 
 class ProcessAssignmentTest(TestCase):
     def setUp(self):

--- a/app/tests/test_reports.py
+++ b/app/tests/test_reports.py
@@ -44,6 +44,9 @@ class ReportAPITest(TestCase):
             is_superuser=True,
         )
 
+        self.role_dtp, _ = Role.objects.get_or_create(name=RoleChoices.DIRECTOR_TECNICO)
+        self.admin_user.roles.add(self.role_dtp)
+
         self.temp_file = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
         self.temp_file.write(b"contenido de prueba del PDF")
         self.temp_file.close()
@@ -726,6 +729,18 @@ class ReportAPITest(TestCase):
         )
         self.assertEqual(response.context["start_date"], start_date_filter)
         self.assertEqual(response.context["end_date"], end_date_filter)
+
+    def test_report_create_view_shows_correct_labels(self):
+        """Verifica que el formulario de creación de reportes muestra las etiquetas en español."""
+        self.client.login(username="adminuser", password="adminpassword")
+        url = reverse("report_create")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        # Verificar algunas de las nuevas etiquetas
+        self.assertContains(response, "Título del Reporte")
+        self.assertContains(response, "Archivo PDF")
+        self.assertContains(response, "Fecha de Vencimiento")
 
 
 class ReportStatusAndNoteTest(TestCase):

--- a/app/views.py
+++ b/app/views.py
@@ -49,6 +49,23 @@ class UserWithProfileForm(UserCreationForm):
         label="Rol",
         required=True,
     )
+    # Redefinir campos en español
+    username = forms.CharField(
+        label="Nombre de Usuario",
+        max_length=150,
+        help_text="Requerido. 150 caracteres o menos. Letras, dígitos y @/./+/-/_ solamente.",
+    )
+    password1 = forms.CharField(
+        label="Contraseña",
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        help_text="La contraseña debe contener al menos 8 caracteres, no puede ser únicamente numérica, no debe ser similar a los otros datos y no puede ser demasiado común.",
+    )
+    password2 = forms.CharField(
+        label="Confirmación de Contraseña",
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        help_text="Introduce la misma contraseña que antes, para su verificación.",
+    )
     # Campos de ClientProfile (solo para cliente)
     razon_social = forms.CharField(required=False)
     nit = forms.CharField(required=False)
@@ -101,6 +118,18 @@ class UserEditWithProfileForm(UserCreationForm):
         queryset=Role.objects.none(),
         label="Rol",
         required=True,
+    )
+    # Redefinir campos en español
+    username = forms.CharField(
+        label="Nombre de Usuario",
+        max_length=150,
+        help_text="Requerido. 150 caracteres o menos. Letras, dígitos y @/./+/-/_ solamente.",
+    )
+    password2 = forms.CharField(
+        label="Confirmación de Contraseña",
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+        help_text="Introduce la misma contraseña que antes, para su verificación.",
     )
     # Campos de ClientProfile (solo para cliente)
     razon_social = forms.CharField(required=False)

--- a/app/views.py
+++ b/app/views.py
@@ -60,6 +60,15 @@ class UserWithProfileForm(UserCreationForm):
 
     class Meta(UserCreationForm.Meta):
         model = User
+        labels = {
+            "username": "Nombre de Usuario",
+            "first_name": "Nombre",
+            "last_name": "Apellido",
+            "email": "Correo Electrónico",
+            "role": "Rol",
+            "password1": "Contraseña",
+            "password2": "Confirmar Contraseña",
+        }
         fields = [
             "username",
             "first_name",
@@ -85,12 +94,6 @@ class UserWithProfileForm(UserCreationForm):
                 if not cleaned_data.get(field):
                     self.add_error(field, "Este campo es obligatorio para clientes.")
         return cleaned_data
-
-
-class UserForm(UserCreationForm):
-    class Meta:
-        model = User
-        fields = ["username", "first_name", "last_name", "email"]
 
 
 class UserEditWithProfileForm(UserCreationForm):
@@ -119,6 +122,15 @@ class UserEditWithProfileForm(UserCreationForm):
             "password1",
             "password2",
         ]
+        labels = {
+            "username": "Nombre de Usuario",
+            "first_name": "Nombre",
+            "last_name": "Apellido",
+            "email": "Correo Electrónico",
+            "role": "Rol",
+            "password1": "Contraseña",
+            "password2": "Confirmar Contraseña",
+        }
 
     def clean_username(self):
         username = self.cleaned_data["username"]
@@ -212,6 +224,16 @@ class ReportForm(forms.ModelForm):
             "estado_reporte",
             "fecha_vencimiento",
         ]
+        labels = {
+            "title": "Título del Reporte",
+            "description": "Descripción",
+            "pdf_file": "Archivo PDF",
+            "user": "Cliente Asociado",
+            "process": "Proceso Asociado",
+            "equipment": "Equipo Asociado",
+            "estado_reporte": "Estado del Reporte",
+            "fecha_vencimiento": "Fecha de Vencimiento",
+        }
         widgets = {
             "fecha_vencimiento": forms.DateInput(attrs={"type": "date"}),
         }
@@ -244,12 +266,22 @@ class ReportStatusAndNoteForm(forms.ModelForm):
     class Meta:
         model = Report
         fields = ["estado_reporte"]
+        labels = {
+            "estado_reporte": "Estado del Reporte",
+        }
 
 
 class ProcessForm(forms.ModelForm):
     class Meta:
         model = Process
         fields = ["process_type", "practice_category", "estado", "user", "fecha_final"]
+        labels = {
+            "process_type": "Tipo de Proceso",
+            "practice_category": "Categoría de la Práctica",
+            "estado": "Estado del Proceso",
+            "user": "Cliente",
+            "fecha_final": "Fecha de Finalización",
+        }
         widgets = {
             "fecha_final": forms.DateTimeInput(
                 attrs={"type": "datetime-local"}, format="%Y-%m-%dT%H:%M"
@@ -277,6 +309,9 @@ class ProcessProgressForm(forms.ModelForm):
     class Meta:
         model = Process
         fields = ["estado"]
+        labels = {
+            "estado": "Estado del Proceso",
+        }
         widgets = {"estado": forms.Select(choices=ProcessStatusChoices.choices)}
 
 
@@ -284,6 +319,11 @@ class ProcessChecklistItemForm(forms.ModelForm):
     class Meta:
         model = ProcessChecklistItem
         fields = ["status", "started_at", "completed_at"]
+        labels = {
+            "status": "Estado del Ítem",
+            "started_at": "Fecha de Inicio",
+            "completed_at": "Fecha de Finalización",
+        }
         widgets = {
             "started_at": forms.DateTimeInput(attrs={"type": "datetime-local"}),
             "completed_at": forms.DateTimeInput(attrs={"type": "datetime-local"}),
@@ -303,6 +343,9 @@ class ProcessAssignmentForm(forms.ModelForm):
     class Meta:
         model = Process
         fields = ["assigned_to"]
+        labels = {
+            "assigned_to": "Asignar a Usuario Interno",
+        }
         widgets = {
             "assigned_to": forms.Select(attrs={"class": "form-select"}),
         }
@@ -319,6 +362,9 @@ class AnotacionForm(forms.ModelForm):
     class Meta:
         model = Anotacion
         fields = ["contenido"]
+        labels = {
+            "contenido": "Contenido de la Anotación",
+        }
         widgets = {
             "fecha_final": forms.DateTimeInput(
                 attrs={"type": "datetime-local"}, format="%Y-%m-%dT%H:%M"
@@ -380,6 +426,22 @@ class EquipmentForm(forms.ModelForm):
             "estado_actual",
             "sede",
         ]
+        labels = {
+            "nombre": "Nombre del Equipo",
+            "marca": "Marca",
+            "modelo": "Modelo",
+            "serial": "Serial",
+            "practica_asociada": "Práctica Asociada",
+            "fecha_adquisicion": "Fecha de Adquisición",
+            "fecha_vigencia_licencia": "Vigencia de la Licencia",
+            "fecha_ultimo_control_calidad": "Último Control de Calidad",
+            "fecha_vencimiento_control_calidad": "Vencimiento del Control de Calidad",
+            "tiene_proceso_de_asesoria": "Tiene Proceso de Asesoría Activo",
+            "user": "Cliente Propietario",
+            "process": "Proceso Principal Asociado",
+            "estado_actual": "Estado Actual",
+            "sede": "Sede",
+        }
         widgets = {
             "fecha_adquisicion": forms.DateInput(attrs={"type": "date"}),
             "fecha_vigencia_licencia": forms.DateInput(attrs={"type": "date"}),
@@ -394,6 +456,11 @@ class HistorialTuboRayosXForm(forms.ModelForm):
     class Meta:
         model = HistorialTuboRayosX
         fields = ["marca", "modelo", "serial"]
+        labels = {
+            "marca": "Marca del Tubo de Rayos X",
+            "modelo": "Modelo del Tubo de Rayos X",
+            "serial": "Serial del Tubo de Rayos X",
+        }
 
 
 def load_user_processes(request):

--- a/templates/process/process_detail.html
+++ b/templates/process/process_detail.html
@@ -6,7 +6,7 @@
 <div class="container mt-4">
     <div class="card">
         <div class="card-header">
-            <h2>{{ process.process_type }}</h2>
+            <h2>{{ process.get_process_type_display }}</h2>
         </div>
         <div class="card-body">
             <div class="row mb-3">


### PR DESCRIPTION
## PR Description: Feat/Change Labels Forms

This pull request focuses on enhancing user experience by updating form labels and templates to display field names in Spanish, ensuring clarity and localization. Additionally, it introduces new test cases to verify these updates. Below is a categorized summary of the most important changes.

### Updates to Form Labels for Localization:
* [`app/views.py`](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR52-R68): Replaced English labels with Spanish labels across multiple forms, including `UserWithProfileForm`, `ProcessForm`, `ReportStatusAndNoteForm`, and others. Examples include "Nombre de Usuario" for `username`, "Estado del Reporte" for `estado_reporte`, and "Fecha de Finalización" for `fecha_final`. [[1]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR52-R68) [[2]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR80-R88) [[3]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR256-R265) [[4]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR298-R313) [[5]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR458-R473)

### Test Cases for Label Verification:
* [`app/tests/test_equipment.py`](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25R415-R428): Added `test_equipment_create_view_shows_correct_labels` to ensure equipment creation form displays Spanish labels like "Nombre del Equipo" and "Práctica Asociada".
* [`app/tests/test_process.py`](diffhunk://#diff-6c03fe862868306d0c4dc5220be1c874a8b789d470501717b9151eefcd73910bR745-R758): Added `test_process_create_view_shows_correct_labels` to verify process creation form labels such as "Tipo de Proceso" and "Cliente".
* [`app/tests/test_reports.py`](diffhunk://#diff-f7ddf751fa9378b7cff247e0177abcd8ed62616830836800dda702516e1e9b8aR733-R744): Added `test_report_create_view_shows_correct_labels` to validate report creation form labels like "Título del Reporte" and "Archivo PDF".

### Template Enhancements:
* [`templates/process/process_detail.html`](diffhunk://#diff-f4a1044dbb078284f92e809ec87e126fd418d7700235fc2672f508d2bf01a8d4L9-R9): Updated the display of `process_type` to use the localized `get_process_type_display` method for better readability.

### Role Assignment in Tests:
* [`app/tests/test_reports.py`](diffhunk://#diff-f7ddf751fa9378b7cff247e0177abcd8ed62616830836800dda702516e1e9b8aR47-R49): Assigned the `DIRECTOR_TECNICO` role to `admin_user` in the `setUp` method, ensuring proper permissions for report-related tests.