### PR TITLE
Feat/Process List New Labels

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -2012,6 +2012,25 @@ class ProcessInternalListView(LoginRequiredMixin, PermissionRequiredMixin, ListV
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        today = timezone.now().date()
+
+        # --- INICIO: Lógica para calcular días de proceso y vencimiento ---
+        for proceso in context["object_list"]:
+            # Calcular días de proceso (desde inicio hasta hoy)
+            if proceso.fecha_inicio:
+                proceso.dias_de_proceso = (today - proceso.fecha_inicio.date()).days
+            else:
+                proceso.dias_de_proceso = None
+
+            # Calcular días para vencimiento (desde hoy hasta fecha final)  y días vencido
+            proceso.dias_hasta_vencimiento = None
+            proceso.dias_vencido = None  # Inicializar el atributo
+            if proceso.fecha_final:
+                dias = (proceso.fecha_final.date() - today).days
+                proceso.dias_hasta_vencimiento = dias
+                if dias < 0:
+                    proceso.dias_vencido = abs(dias)
+        # --- FIN: Lógica para calcular días ---
 
         # Pasar datos para poblar los filtros en el template
         context["process_types"] = [("todos", "Todos")] + ProcessTypeChoices.choices

--- a/templates/process/process_internal_list.html
+++ b/templates/process/process_internal_list.html
@@ -138,6 +138,8 @@
                             <th>Cliente (Razón Social)</th>
                             <th>Asignado a</th>
                             <th>Fecha Fin</th>
+                            <th>Días de Proceso</th>
+                            <th>Días para Vencimiento</th>
                             <th>Avance</th>
                             <th>Acciones</th>
                         </tr>
@@ -159,6 +161,18 @@
                                 {% endif %}
                             </td>
                             <td>{{ proceso.fecha_final|date:"d/m/Y"|default:"N/A" }}</td>
+                            <td>{{ proceso.dias_de_proceso|default:"N/A" }}</td>
+                            <td>
+                                {% if proceso.dias_hasta_vencimiento is not None %}
+                                    {% if proceso.dias_hasta_vencimiento < 0 %}
+                                        <span class="badge bg-danger">Vencido hace {{ proceso.dias_vencido }} días</span>
+                                    {% else %}
+                                        <span class="badge bg-success">{{ proceso.dias_hasta_vencimiento }} días restantes</span>
+                                    {% endif %}
+                                {% else %}
+                                    <span class="text-muted">N/A</span>
+                                {% endif %}
+                            </td>
                             <td>
                                 {% with porcentaje=proceso.get_progress_percentage %}
                                 <div class="progress" style="height: 20px;">


### PR DESCRIPTION
## PR Description: Feat/Process List New Labels

This pull request adds functionality to calculate and display the number of days a process has been active and the days remaining until its deadline. It includes updates to the backend logic, templates, and tests to ensure the new feature works correctly.

### Backend Changes:
* [`app/views.py`](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aR2015-R2033): Added logic in `get_context_data` to calculate `dias_de_proceso`, `dias_hasta_vencimiento`, and `dias_vencido` for each process based on its start and end dates.

### Template Updates:
* [`templates/process/process_internal_list.html`](diffhunk://#diff-8705551578f6829391832c336d0c189095319494a5aa5a0ff3a4af1717b7057bR141-R142): Added new table headers for "Días de Proceso" and "Días para Vencimiento." Updated rows to display calculated values, including badges for overdue or remaining days, and "N/A" for processes without an end date. [[1]](diffhunk://#diff-8705551578f6829391832c336d0c189095319494a5aa5a0ff3a4af1717b7057bR141-R142) [[2]](diffhunk://#diff-8705551578f6829391832c336d0c189095319494a5aa5a0ff3a4af1717b7057bR164-R175)

### Test Additions:
* [`app/tests/test_process.py`](diffhunk://#diff-6c03fe862868306d0c4dc5220be1c874a8b789d470501717b9151eefcd73910bR1062-R1104): Added `test_view_calculates_and_displays_process_days` to verify the correct calculation and display of process days and expiration days in the view, including handling for overdue processes and processes without an end date.