### PR TITLE
Feat/Equipment Type UI

### DIFF
--- a/app/tests/test_equipment.py
+++ b/app/tests/test_equipment.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from ..models import (
     Equipment,
+    EquipmentType,
     EstadoEquipoChoices,
     HistorialTuboRayosX,
     Process,
@@ -125,8 +126,9 @@ class EquipmentAPITest(TestCase):
     def test_equipment_create_view_post_valid(self):
         url = reverse("equipos_create")
         initial_count = Equipment.objects.count()
+        mamografo_type, _ = EquipmentType.objects.get_or_create(name="MAMÓGRAFO")
         data = {
-            "nombre": "Nuevo Equipo Gamma",
+            "equipment_type": mamografo_type.id,
             "marca": "MarcaTest",
             "modelo": "ModeloTest",
             "serial": "SNTEST123",
@@ -140,7 +142,7 @@ class EquipmentAPITest(TestCase):
         self.assertEqual(response.status_code, 302, response.content.decode())
         self.assertEqual(Equipment.objects.count(), initial_count + 1)
         new_equipment = Equipment.objects.latest("id")
-        self.assertEqual(new_equipment.nombre, "Nuevo Equipo Gamma")
+        self.assertEqual(new_equipment.marca, "MarcaTest")
         self.assertEqual(new_equipment.user, self.user_client)
 
     def test_equipment_create_view_post_invalid(self):
@@ -163,6 +165,7 @@ class EquipmentAPITest(TestCase):
         self.assertEqual(response.context["form"].instance, equipment)
 
     def test_equipment_update_view_post_valid(self):
+        mamografo_type, _ = EquipmentType.objects.get_or_create(name="MAMÓGRAFO")
         equipment = Equipment.objects.create(
             nombre="Equipo Original",
             serial="SNORIG",
@@ -171,7 +174,7 @@ class EquipmentAPITest(TestCase):
         )
         url = reverse("equipos_update", args=[equipment.id])
         data = {
-            "nombre": "Equipo Actualizado",
+            "equipment_type": mamografo_type.id,
             "marca": equipment.marca or "NuevaMarca",
             "modelo": equipment.modelo or "NuevoModelo",
             "serial": "SNUPDT",
@@ -186,7 +189,7 @@ class EquipmentAPITest(TestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 302)
         equipment.refresh_from_db()
-        self.assertEqual(equipment.nombre, "Equipo Actualizado")
+        self.assertEqual(equipment.marca, "NuevaMarca")
         self.assertEqual(equipment.serial, "SNUPDT")
         self.assertEqual(equipment.estado_actual, EstadoEquipoChoices.DADO_DE_BAJA)
 
@@ -422,7 +425,7 @@ class EquipmentAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Verificar algunas de las nuevas etiquetas
-        self.assertContains(response, "Nombre del Equipo")
+        self.assertContains(response, "Tipo de Equipo")
         self.assertContains(response, "Práctica Asociada")
         self.assertContains(response, "Cliente Propietario")
 

--- a/app/views.py
+++ b/app/views.py
@@ -455,7 +455,7 @@ class EquipmentForm(forms.ModelForm):
     class Meta:
         model = Equipment
         fields = [
-            "nombre",
+            "equipment_type",
             "marca",
             "modelo",
             "serial",
@@ -471,7 +471,7 @@ class EquipmentForm(forms.ModelForm):
             "sede",
         ]
         labels = {
-            "nombre": "Nombre del Equipo",
+            "equipment_type": "Tipo de Equipo",
             "marca": "Marca",
             "modelo": "Modelo",
             "serial": "Serial",

--- a/templates/equipos/equipos_detail.html
+++ b/templates/equipos/equipos_detail.html
@@ -6,7 +6,7 @@
 <div class="container mt-4">
     <div class="card">
         <div class="card-header">
-            <h2>{{ equipo.nombre }}</h2>
+            <h2>{{ equipo.equipment_type }}</h2>
         </div>
         <div class="card-body">
             <div class="row mb-3">


### PR DESCRIPTION
## PR Description: Feat/Equipment Type UI

This pull request updates the `Equipment` model and associated views, tests, and templates to replace the `nombre` field with `equipment_type`. The changes ensure consistency across the application and improve the representation of equipment data.

### Updates to tests:
* [`app/tests/test_equipment.py`](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25R129-R131): Replaced references to the `nombre` field with `equipment_type` in test cases for equipment creation and update views. Updated assertions to verify the correct handling of `equipment_type` instead of `nombre`. [[1]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25R129-R131) [[2]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25L143-R145) [[3]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25R168) [[4]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25L174-R177) [[5]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25L189-R192) [[6]](diffhunk://#diff-cccb87e89dec3e4880a2c420405e829314697b0b075c2099cfe954c55d635f25L425-R428)

### Updates to views:
* [`app/views.py`](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aL458-R458): Modified the `Meta` class to replace the `nombre` field with `equipment_type` in the `fields` list and updated the corresponding label to "Tipo de Equipo." [[1]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aL458-R458) [[2]](diffhunk://#diff-0c2bad94cd303c5944a38a94f62a63355b8bed2e102dc87c0f44de95cf135b8aL474-R474)

### Updates to templates:
* [`templates/equipos/equipos_detail.html`](diffhunk://#diff-eea4121866b3679293ddc9eb737f2d0f394f78b8770e64ca5b2acdde3b884c8bL9-R9): Updated the equipment detail template to display `equipment_type` instead of `nombre` in the header section.