### PR TITLE
Fix: Enable Presigned URLs for Secure S3 Access

### DIFF
--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -163,7 +163,10 @@ AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
 # Opcional: usar URLs amigables
 AWS_S3_FILE_OVERWRITE = False
 AWS_DEFAULT_ACL = None
-AWS_QUERYSTRING_AUTH = False  # Para que los archivos tengan URL públicas sin tokens
+# Change this from False to True
+AWS_QUERYSTRING_AUTH = True
+# The link will be valid for 1 hour (3600 seconds)
+AWS_QUERYSTRING_EXPIRE = 3600
 
 # (Opcional) Ruta base para tus archivos en el bucket
 AWS_LOCATION = "media"


### PR DESCRIPTION
**Problem**:
Users are receiving a 403 AccessDenied error when attempting to view uploaded files (PDFs). This is because the S3 bucket is correctly configured to be private, but the Django application was generating simple, non-authenticated URLs.

**Solution**:
This PR modifies settings.py to enable S3 presigned URLs by setting AWS_QUERYSTRING_AUTH = True. This instructs the application to generate secure, temporary links that grant access to private objects in the S3 bucket.

**Impact**:
This resolves the AccessDenied error and implements the correct, secure method for serving private files to authorized users.