### PR TITLE
Feat/Various Fixes And Improvements

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils import timezone
 
 from .models import (
     Anotacion,
@@ -122,7 +123,8 @@ class AnotacionAdmin(admin.ModelAdmin):
     readonly_fields = ("fecha_creacion",)
 
     def fecha_creacion_display(self, obj):
-        return obj.fecha_creacion.strftime("%Y-%m-%d %H:%M")
+        local_time = timezone.localtime(obj.fecha_creacion)
+        return local_time.strftime("%Y-%m-%d %H:%M")
 
     fecha_creacion_display.short_description = "Fecha Creación"
 
@@ -158,6 +160,7 @@ class ProcessStatusLogAdmin(admin.ModelAdmin):
     readonly_fields = ("fecha_cambio",)
 
     def fecha_cambio_display(self, obj):
-        return obj.fecha_cambio.strftime("%Y-%m-%d %H:%M")
+        local_time = timezone.localtime(obj.fecha_cambio)
+        return local_time.strftime("%Y-%m-%d %H:%M")
 
     fecha_cambio_display.short_description = "Fecha Cambio"

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from app.storage import PDFStorage
@@ -504,7 +505,9 @@ class Anotacion(models.Model):
         process_id = self.proceso.id
         user_display = self.usuario.username if self.usuario else "Sistema"
         # auto_now_add=True ensures fecha_creacion is set, so direct strftime is safe
-        date_display = self.fecha_creacion.strftime("%Y-%m-%d %H:%M")
+        # Convertir la fecha a la zona horaria local antes de formatearla
+        local_fecha_creacion = timezone.localtime(self.fecha_creacion)
+        date_display = local_fecha_creacion.strftime("%Y-%m-%d %H:%M")
         return (
             f"Anotación para {process_display} ({process_id}) "
             f"por {user_display} el {date_display}"
@@ -716,14 +719,17 @@ class ProcessStatusLog(models.Model):
         )
         estado_nuevo_display = self.get_estado_nuevo_display()
 
+        # Convertir la fecha a la zona horaria local antes de formatearla
+        local_fecha_cambio = timezone.localtime(self.fecha_cambio)
+
         return _(
-            "Proceso %(proceso_display)s: %(estado_anterior_display)s -> %(estado_nuevo_display)s por %(user_display)s el %(fecha_cambio)s"
+            "Proceso %(proceso_display)s: %(estado_anterior_display)s -> %(estado_nuevo_display)s por %(user_display)s el %(local_fecha_cambio)s"
         ) % {
             "proceso_display": proceso_display,
             "estado_anterior_display": estado_anterior_display,
             "estado_nuevo_display": estado_nuevo_display,
             "user_display": user_display,
-            "fecha_cambio": self.fecha_cambio.strftime("%Y-%m-%d %H:%M"),
+            "local_fecha_cambio": local_fecha_cambio.strftime("%Y-%m-%d %H:%M"),
         }
 
     class Meta:

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -598,7 +598,8 @@ class AnotacionModelTest(TestCase):
             usuario=self.user1,
             contenido="Contenido para str.",
         )
-        expected_str = f"Anotación para {self.process.get_process_type_display()} ({self.process.id}) por {self.user1.username} el {anotacion.fecha_creacion.strftime('%Y-%m-%d %H:%M')}"
+        fecha = timezone.localtime(anotacion.fecha_creacion).strftime("%Y-%m-%d %H:%M")
+        expected_str = f"Anotación para {self.process.get_process_type_display()} ({self.process.id}) por {self.user1.username} el {fecha}"
         self.assertEqual(str(anotacion), expected_str)
 
     def test_anotacion_string_representation_no_user(self):
@@ -606,7 +607,7 @@ class AnotacionModelTest(TestCase):
         anotacion = Anotacion.objects.create(
             proceso=self.process, usuario=None, contenido="Sistema generó esta nota."
         )
-        expected_str = f"Anotación para {self.process.get_process_type_display()} ({self.process.id}) por Sistema el {anotacion.fecha_creacion.strftime('%Y-%m-%d %H:%M')}"
+        expected_str = f"Anotación para {self.process.get_process_type_display()} ({self.process.id}) por Sistema el {timezone.localtime(anotacion.fecha_creacion).strftime('%Y-%m-%d %H:%M')}"
         self.assertEqual(str(anotacion), expected_str)
 
     def test_anotacion_ordering(self):
@@ -787,7 +788,7 @@ class ProcessStatusLogModelTest(TestCase):
         expected_str = (
             f"Proceso {expected_str_part_proceso}: {ProcessStatusChoices.EN_PROGRESO.label} -> "
             f"{ProcessStatusChoices.EN_REVISION.label} por {self.user2.username} el "
-            f"{log_entry.fecha_cambio.strftime('%Y-%m-%d %H:%M')}"
+            f"{timezone.localtime(log_entry.fecha_cambio).strftime('%Y-%m-%d %H:%M')}"
         )
         self.assertEqual(str(log_entry), expected_str)
 
@@ -806,7 +807,7 @@ class ProcessStatusLogModelTest(TestCase):
         expected_str = (
             f"Proceso {expected_str_part_proceso}: N/A -> "
             f"{ProcessStatusChoices.FINALIZADO.label} por Sistema el "
-            f"{log_entry.fecha_cambio.strftime('%Y-%m-%d %H:%M')}"
+            f"{timezone.localtime(log_entry.fecha_cambio).strftime('%Y-%m-%d %H:%M')}"
         )
         self.assertEqual(str(log_entry), expected_str)
         self.assertEqual(

--- a/app/tests/test_process.py
+++ b/app/tests/test_process.py
@@ -44,8 +44,12 @@ class ProcessAPITest(TestCase):
             # fecha_inicio se setea automáticamente por auto_now_add
         )
         # Forzar fechas para testing preciso
-        self.proc1.fecha_inicio = datetime(2023, 3, 10, tzinfo=timezone.utc)
-        self.proc1.fecha_final = datetime(2023, 9, 15, tzinfo=timezone.utc)
+        self.proc1.fecha_inicio = datetime(
+            2023, 3, 10, tzinfo=timezone(-timedelta(hours=5))
+        )
+        self.proc1.fecha_final = datetime(
+            2023, 9, 15, tzinfo=timezone(-timedelta(hours=5))
+        )
         self.proc1.save()
 
         # Anotaciones para el proceso 1
@@ -54,7 +58,7 @@ class ProcessAPITest(TestCase):
             usuario=self.admin_user,
             contenido="Primera anotación para P1",
             fecha_creacion=datetime(
-                2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc
+                2023, 1, 1, 10, 0, 0, tzinfo=timezone(-timedelta(hours=5))
             ),  # Fecha explícita
         )
         self.anotacion2_p1 = Anotacion.objects.create(
@@ -62,15 +66,19 @@ class ProcessAPITest(TestCase):
             usuario=self.user,
             contenido="Segunda anotación para P1",
             fecha_creacion=datetime(
-                2023, 1, 2, 11, 0, 0, tzinfo=timezone.utc
+                2023, 1, 2, 11, 0, 0, tzinfo=timezone(-timedelta(hours=5))
             ),  # Fecha explícita
         )
         # Forzar la actualización de fecha_creacion si auto_now_add interfiere con fechas explícitas
         Anotacion.objects.filter(id=self.anotacion1_p1.id).update(
-            fecha_creacion=datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+            fecha_creacion=datetime(
+                2023, 1, 1, 10, 0, 0, tzinfo=timezone(-timedelta(hours=5))
+            )
         )
         Anotacion.objects.filter(id=self.anotacion2_p1.id).update(
-            fecha_creacion=datetime(2023, 1, 2, 11, 0, 0, tzinfo=timezone.utc)
+            fecha_creacion=datetime(
+                2023, 1, 2, 11, 0, 0, tzinfo=timezone(-timedelta(hours=5))
+            )
         )
         self.anotacion1_p1.refresh_from_db()
         self.anotacion2_p1.refresh_from_db()
@@ -80,8 +88,12 @@ class ProcessAPITest(TestCase):
             process_type=ProcessTypeChoices.CONTROL_CALIDAD,
             estado=ProcessStatusChoices.FINALIZADO,
         )
-        self.proc2.fecha_inicio = datetime(2023, 8, 5, tzinfo=timezone.utc)
-        self.proc2.fecha_final = datetime(2024, 1, 20, tzinfo=timezone.utc)
+        self.proc2.fecha_inicio = datetime(
+            2023, 8, 5, tzinfo=timezone(-timedelta(hours=5))
+        )
+        self.proc2.fecha_final = datetime(
+            2024, 1, 20, tzinfo=timezone(-timedelta(hours=5))
+        )
         self.proc2.save()
 
         self.proc3_admin = Process.objects.create(  # Proceso de otro usuario
@@ -89,7 +101,9 @@ class ProcessAPITest(TestCase):
             process_type=ProcessTypeChoices.CALCULO_BLINDAJES,
             estado=ProcessStatusChoices.EN_REVISION,
         )
-        self.proc3_admin.fecha_inicio = datetime(2024, 2, 1, tzinfo=timezone.utc)
+        self.proc3_admin.fecha_inicio = datetime(
+            2024, 2, 1, tzinfo=timezone(-timedelta(hours=5))
+        )
         self.proc3_admin.save()
 
         self.proc4_no_final = Process.objects.create(  # Sin fecha final
@@ -97,7 +111,9 @@ class ProcessAPITest(TestCase):
             process_type=ProcessTypeChoices.OTRO,
             estado=ProcessStatusChoices.RADICADO,
         )
-        self.proc4_no_final.fecha_inicio = datetime(2024, 3, 1, tzinfo=timezone.utc)
+        self.proc4_no_final.fecha_inicio = datetime(
+            2024, 3, 1, tzinfo=timezone(-timedelta(hours=5))
+        )
         self.proc4_no_final.save()
 
         # Equipos asociados a estos procesos (ya que la vista lista equipos)
@@ -128,10 +144,10 @@ class ProcessAPITest(TestCase):
             user=self.user,
             process_type=self.pt_asesoria,
             estado=self.estado_progreso,
-            fecha_inicio=datetime(2023, 1, 10, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2023, 1, 10, tzinfo=timezone(-timedelta(hours=5))),
         )
         self.proceso1_asesoria_progreso.fecha_inicio = datetime(
-            2023, 1, 10, tzinfo=timezone.utc
+            2023, 1, 10, tzinfo=timezone(-timedelta(hours=5))
         )
         self.proceso1_asesoria_progreso.save()
 
@@ -139,11 +155,11 @@ class ProcessAPITest(TestCase):
             user=self.user,
             process_type=self.pt_calidad,
             estado=self.estado_finalizado,
-            fecha_inicio=datetime(2023, 2, 10, tzinfo=timezone.utc),
-            fecha_final=datetime(2023, 2, 20, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2023, 2, 10, tzinfo=timezone(-timedelta(hours=5))),
+            fecha_final=datetime(2023, 2, 20, tzinfo=timezone(-timedelta(hours=5))),
         )
         self.proceso2_calidad_finalizado.fecha_inicio = datetime(
-            2023, 2, 10, tzinfo=timezone.utc
+            2023, 2, 10, tzinfo=timezone(-timedelta(hours=5))
         )
         self.proceso2_calidad_finalizado.save()
 
@@ -151,10 +167,10 @@ class ProcessAPITest(TestCase):
             user=self.user,
             process_type=self.pt_blindajes,
             estado=self.estado_progreso,
-            fecha_inicio=datetime(2023, 4, 10, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2023, 4, 10, tzinfo=timezone(-timedelta(hours=5))),
         )
         self.proceso4_blindajes_progreso.fecha_inicio = datetime(
-            2023, 4, 10, tzinfo=timezone.utc
+            2023, 4, 10, tzinfo=timezone(-timedelta(hours=5))
         )
         self.proceso4_blindajes_progreso.save()
 
@@ -1138,7 +1154,7 @@ class ProcessListViewTest(TestCase):
         process_old = Process.objects.create(
             user=client_user,
             process_type=ProcessTypeChoices.ASESORIA,
-            fecha_inicio=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2024, 1, 1, tzinfo=timezone(-timedelta(hours=5))),
         )
         equipment.process = process_old
         equipment.save()
@@ -1146,7 +1162,7 @@ class ProcessListViewTest(TestCase):
         process_new = Process.objects.create(
             user=client_user,
             process_type=ProcessTypeChoices.ASESORIA,
-            fecha_inicio=datetime(2024, 6, 1, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2024, 6, 1, tzinfo=timezone(-timedelta(hours=5))),
         )
         Report.objects.create(
             user=client_user,

--- a/app/tests/test_reports.py
+++ b/app/tests/test_reports.py
@@ -67,20 +67,20 @@ class ReportAPITest(TestCase):
             user=self.user,
             process_type=self.process_type_asesoria,
             estado=self.process_status_progreso,
-            fecha_inicio=datetime(2024, 1, 10, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2024, 1, 10, tzinfo=timezone(-timedelta(hours=5))),
         )
         self.process_calidad = Process.objects.create(
             user=self.user,
             process_type=self.process_type_calidad,
             estado=self.process_status_progreso,
-            fecha_inicio=datetime(2024, 2, 15, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2024, 2, 15, tzinfo=timezone(-timedelta(hours=5))),
         )
         # Proceso para otro usuario (admin en este caso, para probar que no se listen sus reportes para el cliente)
         self.process_admin = Process.objects.create(
             user=self.admin_user,
             process_type=self.process_type_asesoria,
             estado=self.process_status_progreso,
-            fecha_inicio=datetime(2024, 3, 1, tzinfo=timezone.utc),
+            fecha_inicio=datetime(2024, 3, 1, tzinfo=timezone(-timedelta(hours=5))),
         )
 
         self.equipment1_calidad = Equipment.objects.create(
@@ -112,7 +112,7 @@ class ReportAPITest(TestCase):
         )
         # Forzar created_at para pruebas de filtro de fecha precisas
         self.report1_asesoria_jan.created_at = datetime(
-            2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
+            2024, 1, 15, 10, 0, 0, tzinfo=timezone(-timedelta(hours=5))
         )
         self.report1_asesoria_jan.save()
 
@@ -125,7 +125,7 @@ class ReportAPITest(TestCase):
             estado_reporte=EstadoReporteChoices.REVISADO,
         )
         self.report2_calidad_feb.created_at = datetime(
-            2024, 2, 20, 11, 0, 0, tzinfo=timezone.utc
+            2024, 2, 20, 11, 0, 0, tzinfo=timezone(-timedelta(hours=5))
         )
         self.report2_calidad_feb.save()
 
@@ -137,7 +137,7 @@ class ReportAPITest(TestCase):
             estado_reporte=EstadoReporteChoices.APROBADO,
         )
         self.report3_asesoria_mar.created_at = datetime(
-            2024, 3, 25, 12, 0, 0, tzinfo=timezone.utc
+            2024, 3, 25, 12, 0, 0, tzinfo=timezone(-timedelta(hours=5))
         )
         self.report3_asesoria_mar.save()
 
@@ -150,7 +150,7 @@ class ReportAPITest(TestCase):
             estado_reporte=EstadoReporteChoices.APROBADO,
         )
         self.report_admin_user.created_at = datetime(
-            2024, 3, 10, 10, 0, 0, tzinfo=timezone.utc
+            2024, 3, 10, 10, 0, 0, tzinfo=timezone(-timedelta(hours=5))
         )
         self.report_admin_user.save()
 
@@ -704,7 +704,9 @@ class ReportAPITest(TestCase):
             title="Reporte Calidad Enero para Equipo1",
             pdf_file=SimpleUploadedFile("cc_enero.pdf", self.temp_file_content),
         )
-        report_cc_anterior.created_at = datetime(2024, 1, 20, tzinfo=timezone.utc)
+        report_cc_anterior.created_at = datetime(
+            2024, 1, 20, tzinfo=timezone(-timedelta(hours=5))
+        )
         report_cc_anterior.save()
 
         # self.report2_calidad_feb.created_at es 2024-02-20

--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -141,7 +141,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/Bogota"
 
 USE_I18N = True
 

--- a/templates/dashboard_cliente.html
+++ b/templates/dashboard_cliente.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %} {# Necesario para íconos si los usas localmente, o usa CDN de FontAwesome #}
+{% load tz %}
 
 {% block title %}Dashboard del Cliente{% endblock %}
 
@@ -145,7 +146,7 @@
                                         <td>{{ equipo.marca }}</td>
                                         <td>{{ equipo.modelo }}</td>
                                         <td>{{ equipo.serial }}</td>
-                                        <td>{{ equipo.fecha_vigencia_licencia|date:"d/m/Y" }}</td>
+                                        <td>{{ equipo.fecha_vigencia_licencia|localtime|date:"d/m/Y" }}</td>
                                     </tr>
                                     {% endfor %}
                                 </tbody>
@@ -180,7 +181,7 @@
                                         <td>{{ equipo.marca }}</td>
                                         <td>{{ equipo.modelo }}</td>
                                         <td>{{ equipo.serial }}</td>
-                                        <td>{{ equipo.fecha_vencimiento_control_calidad|date:"d/m/Y" }}</td>
+                                        <td>{{ equipo.fecha_vencimiento_control_calidad|localtime|date:"d/m/Y" }}</td>
                                     </tr>
                                     {% endfor %}
                                 </tbody>
@@ -213,7 +214,7 @@
                                     <tr>
                                         <td>{{ proceso_item.get_process_type_display }}</td>
                                         <td><span class="badge bg-info text-dark">{{ proceso_item.get_estado_display }}</span></td>
-                                        <td>{{ proceso_item.fecha_inicio|date:"d/m/Y" }}</td>
+                                        <td>{{ proceso_item.fecha_inicio|localtime|date:"d/m/Y" }}</td>
                                         {% with porcentaje=proceso_item.get_progress_percentage %}
                                             <td>
                                                 {% if porcentaje %}

--- a/templates/dashboard_gerente.html
+++ b/templates/dashboard_gerente.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load tz %}
 
 {% block title %}Dashboard - Gerente{% endblock %}
 
@@ -99,7 +100,7 @@
                                         <small>
                                             <strong>Cliente:</strong> {{ proceso.user.client_profile.razon_social|default:"N/A" }} <br>
                                             <strong>Asignado a:</strong> {{ proceso.assigned_to.get_full_name|default:"Sin asignar" }} <br>
-                                            <strong>Venció el:</strong> {{ proceso.fecha_final|date:"d/m/Y" }}
+                                            <strong>Venció el:</strong> {{ proceso.fecha_final|localtime|date:"d/m/Y" }}
                                             <span class="badge bg-danger rounded-pill">{{ proceso.dias_vencido }} días vencido</span>
                                         </small>
                                     </li>
@@ -126,7 +127,7 @@
                                         <small>
                                             <strong>Cliente:</strong> {{ proceso.user.client_profile.razon_social|default:"N/A" }} <br>
                                             <strong>Asignado a:</strong> {{ proceso.assigned_to.get_full_name|default:"Sin asignar" }} <br>
-                                            <strong>Vence el:</strong> {{ proceso.fecha_final|date:"d/m/Y" }}
+                                            <strong>Vence el:</strong> {{ proceso.fecha_final|localtime|date:"d/m/Y" }}
                                         </small>
                                     </li>
                                 {% endfor %}

--- a/templates/dashboard_interno.html
+++ b/templates/dashboard_interno.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load tz %}
 
 {% block title %}{{ titulo }}{% endblock %}
 
@@ -51,7 +52,7 @@
                                         <br>
                                         <small>
                                             <strong>Cliente:</strong> {{ proceso.user.client_profile.razon_social|default:"N/A" }} <br>
-                                            <strong>Venció el:</strong> {{ proceso.fecha_final|date:"d/m/Y" }}
+                                            <strong>Venció el:</strong> {{ proceso.fecha_final|localtime|date:"d/m/Y" }}
                                             <span class="badge bg-danger rounded-pill">{{ proceso.dias_vencido }} días vencido</span>
                                         </small>
                                     </li>
@@ -77,7 +78,7 @@
                                         <br>
                                         <small>
                                             <strong>Cliente:</strong> {{ proceso.user.client_profile.razon_social|default:"N/A" }} <br>
-                                            <strong>Vence el:</strong> {{ proceso.fecha_final|date:"d/m/Y" }}
+                                            <strong>Vence el:</strong> {{ proceso.fecha_final|localtime|date:"d/m/Y" }}
                                         </small>
                                     </li>
                                 {% endfor %}

--- a/templates/equipos/equipos_detail.html
+++ b/templates/equipos/equipos_detail.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load tz %}
+
 {% block title %}Detalle de Equipo{% endblock %}
 
 {% block content %}
@@ -48,19 +50,19 @@
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Adquisición:</strong></div>
-                <div class="col-md-8">{{ equipo.fecha_adquisicion|date:"d/m/Y" }}</div>
+                <div class="col-md-8">{{ equipo.fecha_adquisicion|localtime|date:"d/m/Y" }}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Vigencia de Licencia:</strong></div>
-                <div class="col-md-8">{{ equipo.fecha_vigencia_licencia|date:"d/m/Y"|default_if_none:"No Aplica" }}</div>
+                <div class="col-md-8">{{ equipo.fecha_vigencia_licencia|localtime|date:"d/m/Y"|default_if_none:"No Aplica" }}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Último Control de Calidad:</strong></div>
-                <div class="col-md-8">{{ equipo.fecha_ultimo_control_calidad|date:"d/m/Y"|default_if_none:"No Aplica" }}</div>
+                <div class="col-md-8">{{ equipo.fecha_ultimo_control_calidad|localtime|date:"d/m/Y"|default_if_none:"No Aplica" }}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Vencimiento del Control de Calidad:</strong></div>
-                <div class="col-md-8">{{ equipo.fecha_vencimiento_control_calidad|date:"d/m/Y"|default_if_none:"No Aplica"}}</div>
+                <div class="col-md-8">{{ equipo.fecha_vencimiento_control_calidad|localtime|date:"d/m/Y"|default_if_none:"No Aplica"}}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>¿Tiene proceso de Asesoría?</strong></div>
@@ -159,7 +161,7 @@
                 <li class="list-group-item">
                     Marca del Tubo: {{ tubo.marca }} - Modelo del Tubo: {{ tubo.modelo }} <br> (Serial del tubo: {{ tubo.serial }})
                     <br>
-                    <small class="text-muted">{{ tubo.fecha_cambio|date:"d/m/Y" }}</small>
+                    <small class="text-muted">{{ tubo.fecha_cambio|localtime|date:"d/m/Y" }}</small>
                 </li>
                 {% endfor %}
             </ul>

--- a/templates/equipos/equipos_list.html
+++ b/templates/equipos/equipos_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load app_extras %}
+{% load tz %}
 
 {% block title %}Lista de Equipos{% endblock %}
 
@@ -264,14 +265,14 @@
                             <td>{{ equipo.modelo }}</td>
                             <td>{{ equipo.serial }}</td>
                             <td>{{ equipo.practica_asociada }}</td>
-                            <td>{{ equipo.fecha_adquisicion|date:"d/m/Y" }}</td>
+                            <td>{{ equipo.fecha_adquisicion|localtime|date:"d/m/Y" }}</td>
                             <td>
-                                {{ equipo.fecha_vigencia_licencia|date:"d/m/Y" }}
+                                {{ equipo.fecha_vigencia_licencia|localtime|date:"d/m/Y" }}
                                 {% if equipo.licencia_vence_pronto %}<span class="badge bg-warning text-dark ms-1">Por Vencer</span>{% endif %}
                             </td>
-                            <td>{{ equipo.fecha_ultimo_control_calidad|date:"d/m/Y" }}</td>
+                            <td>{{ equipo.fecha_ultimo_control_calidad|localtime|date:"d/m/Y" }}</td>
                             <td>
-                                {{ equipo.fecha_vencimiento_control_calidad|date:"d/m/Y" }}
+                                {{ equipo.fecha_vencimiento_control_calidad|localtime|date:"d/m/Y" }}
                                 {% if equipo.cc_vence_pronto %}<span class="badge bg-danger text-white ms-1">Vence Pronto</span>{% endif %}
                             </td>
                             <td>{{ equipo.get_estado_actual_display }}</td>

--- a/templates/process/process_detail.html
+++ b/templates/process/process_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block title %}Detalle de Proceso{% endblock %}
 
@@ -52,11 +53,11 @@
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Inicio:</strong></div>
-                <div class="col-md-8">{{ process.fecha_inicio|date:"d/m/Y H:i" }}</div>
+                <div class="col-md-8">{{ process.fecha_inicio|localtime|date:"d/m/Y H:i" }}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Finalización:</strong></div>
-                <div class="col-md-8">{{ process.fecha_final|date:"d/m/Y H:i" }}</div>
+                <div class="col-md-8">{{ process.fecha_final|localtime|date:"d/m/Y H:i" }}</div>
             </div>
         </div>
         <div class="card-footer">
@@ -80,7 +81,7 @@
                 {% for anotacion in process.anotaciones.all %}
                 <li class="list-group-item">
                     <strong>{{ anotacion.usuario.username }}:</strong> {{ anotacion.contenido }} <br>
-                    <small class="text-muted">{{ anotacion.fecha_creacion|date:"d/m/Y H:i" }}</small>
+                    <small class="text-muted">{{ anotacion.fecha_creacion|localtime|date:"d/m/Y H:i" }}</small>
                 </li>
                 {% endfor %}
             </ul>

--- a/templates/process/process_internal_list.html
+++ b/templates/process/process_internal_list.html
@@ -167,7 +167,11 @@
                             <td>
                                 {% if proceso.dias_hasta_vencimiento is not None %}
                                     {% if proceso.dias_hasta_vencimiento < 0 %}
-                                        <span class="badge bg-danger">Vencido hace {{ proceso.dias_vencido }} días</span>
+                                        {% if proceso.estado == 'finalizado' %}
+                                            <span class="badge bg-secondary">Finalizado hace {{ proceso.dias_vencido }} días</span>
+                                        {% else %}
+                                            <span class="badge bg-danger">Vencido hace {{ proceso.dias_vencido }} días</span>
+                                        {% endif %}
                                     {% else %}
                                         <span class="badge bg-success">{{ proceso.dias_hasta_vencimiento }} días restantes</span>
                                     {% endif %}

--- a/templates/process/process_internal_list.html
+++ b/templates/process/process_internal_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load app_extras %}
+{% load tz %}
 
 {% block title %}Lista de Procesos{% endblock %}
 
@@ -161,7 +162,7 @@
                                     <span class="text-muted">Sin asignar</span>
                                 {% endif %}
                             </td>
-                            <td>{{ proceso.fecha_final|date:"d/m/Y"|default:"N/A" }}</td>
+                            <td>{{ proceso.fecha_final|localtime|date:"d/m/Y"|default:"N/A" }}</td>
                             <td>{{ proceso.dias_de_proceso|default:"N/A" }}</td>
                             <td>
                                 {% if proceso.dias_hasta_vencimiento is not None %}

--- a/templates/process/process_list.html
+++ b/templates/process/process_list.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block title %}Lista de Procesos{% endblock %}
 
@@ -108,7 +109,7 @@
                             <td>{{ equipo.modelo }}</td>
                             <td>{{ equipo.serial }}</td>
                             {% with progress_data=equipment_progress_map|get_item:equipo.id %}
-                            <td>{{ progress_data.process.fecha_inicio|date:"d/m/Y"|default:"N/A" }}</td>
+                            <td>{{ progress_data.process.fecha_inicio|localtime|date:"d/m/Y"|default:"N/A" }}</td>
                             <td>{{ equipo.get_estado_actual_display }}</td>
                             <td>
                                 {% if progress_data.process %}

--- a/templates/process/process_progress_form.html
+++ b/templates/process/process_progress_form.html
@@ -10,7 +10,7 @@
     <form method="post">
         {% csrf_token %}
         {{ form|crispy }}
-        <h4>Checklist</h4>
+        <h4>Lista de Chequeo</h4>
         <table class="table">
             <thead>
                 <tr>

--- a/templates/process/process_progress_form.html
+++ b/templates/process/process_progress_form.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load crispy_forms_tags %}
+{% load tz %}
 
 {% block title %}Actualizar Progreso del Proceso{% endblock %}
 
@@ -31,7 +32,7 @@
                     </td>
                     <td>{{ item_form.started_at }}</td>
                     <td>{{ item_form.completed_at }}</td>
-                    <td>{{ item_form.due_date }}</td>
+                    <td>{{ item_form.due_date|localtime }}</td>
                     <td>
                         {% if item_form.instance.is_completed and item_form.instance.completed_by %}
                             {{ item_form.instance.completed_by.get_full_name|default:item_form.instance.completed_by.username }}

--- a/templates/reports/report_detail.html
+++ b/templates/reports/report_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block title %}Detalle de Reporte{% endblock %}
 
@@ -22,7 +23,7 @@
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Fecha de Creación:</strong></div>
-                <div class="col-md-8">{{ report.created_at|date:"d/m/Y H:i" }}</div>
+                <div class="col-md-8">{{ report.created_at|localtime|date:"d/m/Y H:i" }}</div>
             </div>
             <div class="row mb-3">
                 <div class="col-md-4"><strong>Archivo PDF:</strong></div>
@@ -61,7 +62,7 @@
                 {% for anotacion in report.process.anotaciones.all %}
                 <li class="list-group-item">
                     <strong>{{ anotacion.usuario.username }}:</strong> {{ anotacion.contenido }} <br>
-                    <small class="text-muted">{{ anotacion.fecha_creacion|date:"d/m/Y H:i" }}</small>
+                    <small class="text-muted">{{ anotacion.fecha_creacion|localtime|date:"d/m/Y H:i" }}</small>
                 </li>
                 {% endfor %}
             </ul>

--- a/templates/reports/report_list.html
+++ b/templates/reports/report_list.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load app_extras %}
+{% load tz %}
 
 {% block title %}Lista de Reportes{% endblock %}
 
@@ -163,7 +164,7 @@
                             <td>{{ report.title }}</td>
                             <td>{{ report.user.username }}</td>
                             <td>{{ report.description|truncatechars:50 }}</td>
-                            <td>{{ report.created_at|date:"d/m/Y H:i" }}</td>
+                            <td>{{ report.created_at|localtime|date:"d/m/Y H:i" }}</td>
                             <td>
                                 <a href="{% url 'report_detail' report.id %}" class="btn btn-sm btn-info">Ver</a>
                                 {% if perms.app.change_report%}


### PR DESCRIPTION
## PR Description: Feat/Various Fixes And Improvements

This pull request introduces changes to ensure that all date and time values are displayed in the local timezone (America/Bogota) instead of UTC. The updates affect both the backend logic and the frontend templates, as well as the test cases to align with the new timezone handling. Below is a summary of the most important changes grouped by theme:

### Backend Updates for Timezone Handling
* Updated `app/admin.py` to use `timezone.localtime` for formatting `fecha_creacion` and `fecha_cambio` in the `AnotacionAdmin` and `ProcessStatusLogAdmin` classes. [[1]](diffhunk://#diff-2e6f3da0a0e6f1e7448e06ec253a41912c5ce0841f76e1e43f11d1b6c8d3a24bL125-R127) [[2]](diffhunk://#diff-2e6f3da0a0e6f1e7448e06ec253a41912c5ce0841f76e1e43f11d1b6c8d3a24bL161-R164)
* Modified `app/models.py` to use `timezone.localtime` when formatting `fecha_creacion` and `fecha_cambio` in the `__str__` methods of relevant models. [[1]](diffhunk://#diff-90c680eba43456b516da8b4c2573d467ae17d1b0ed4373549f2a593ced3616d5L507-R510) [[2]](diffhunk://#diff-90c680eba43456b516da8b4c2573d467ae17d1b0ed4373549f2a593ced3616d5R722-R732)
* Changed the default timezone in `app_server/settings.py` from `"UTC"` to `"America/Bogota"`.

### Frontend Updates for Local Timezone Display
* Updated `templates/dashboard_cliente.html` to use the `localtime` template filter for displaying dates in the local timezone. This affects fields such as `fecha_vigencia_licencia`, `fecha_vencimiento_control_calidad`, and `fecha_inicio`. [[1]](diffhunk://#diff-9ff3df3d5e14a0aeb594917cfb5c9868b93c0d584fb3b0bd4c4231c0d9ccc1fbL148-R149) [[2]](diffhunk://#diff-9ff3df3d5e14a0aeb594917cfb5c9868b93c0d584fb3b0bd4c4231c0d9ccc1fbL183-R184) [[3]](diffhunk://#diff-9ff3df3d5e14a0aeb594917cfb5c9868b93c0d584fb3b0bd4c4231c0d9ccc1fbL216-R217)

### Test Adjustments for Timezone Changes
* Updated tests in `app/tests/test_models.py`, `app/tests/test_process.py`, and `app/tests/test_reports.py` to set explicit timezones (`timezone(-timedelta(hours=5))`) for test data and to use `timezone.localtime` when comparing expected and actual string representations of date-related fields. [[1]](diffhunk://#diff-917e292b7e8d626912c269e249a7cf41de30c75b0285f3057b2ad6eb87a9f238L601-R610) [[2]](diffhunk://#diff-6c03fe862868306d0c4dc5220be1c874a8b789d470501717b9151eefcd73910bL47-R52) [[3]](diffhunk://#diff-f7ddf751fa9378b7cff247e0177abcd8ed62616830836800dda702516e1e9b8aL70-R83)

These changes ensure consistent timezone handling across the application, improving accuracy and user experience for users in the specified timezone.