### PR TITLE
Feat/Secret Key Fallback Env Variable

### DIFF
--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -12,7 +12,7 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # Fallback for SECRET KEY when rotating the SECRET_KEY to avoid invalidating existing sessions
 fallback_key = os.getenv("DJANGO_SECRET_KEY_FALLBACK")
-SECRET_KEY_FALLBACK = [fallback_key] if fallback_key else []
+SECRET_KEY_FALLBACKS = [fallback_key] if fallback_key else []
 
 DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 AUTH_USER_MODEL = "app.User"

--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -10,6 +10,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
+# Fallback for SECRET KEY when rotating the SECRET_KEY to avoid invalidating existing sessions
+fallback_key = os.getenv("DJANGO_SECRET_KEY_FALLBACK")
+SECRET_KEY_FALLBACK = [fallback_key] if fallback_key else []
+
 DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 AUTH_USER_MODEL = "app.User"
 


### PR DESCRIPTION
## PR Description: Feat/Secret Key Fallback Env Variable

This pull request introduces a fallback mechanism for the `SECRET_KEY` in the `app_server/settings.py` file to ensure session continuity during key rotation.

* **Fallback for `SECRET_KEY`**:
  - Added a `fallback_key` that retrieves the value of `DJANGO_SECRET_KEY_FALLBACK` from the environment.
  - Introduced `SECRET_KEY_FALLBACKS` to store the fallback key if it is provided, ensuring existing sessions remain valid during `SECRET_KEY` rotation.