### PR TITLE
Feat/Email Config

### DIFF
--- a/app_server/settings.py
+++ b/app_server/settings.py
@@ -231,3 +231,14 @@ if not DEBUG:
     SECURE_HSTS_SECONDS = 31536000  # 1 año
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
+
+
+# Email Config
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.example.com")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "user@example.com")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "password")
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "webmaster@example.com")


### PR DESCRIPTION
## PR Description: Feat/Email Config

This pull request introduces email configuration settings to the `app_server/settings.py` file, enabling SMTP-based email functionality.

### Email Configuration:

* Added settings for `EMAIL_BACKEND`, `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USE_TLS`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, and `DEFAULT_FROM_EMAIL` to configure SMTP email functionality. These settings use environment variables with default values for flexibility. (`[app_server/settings.pyR234-R244](diffhunk://#diff-2f324bf5f20db9823c693cf7ae7d23b14503d0df2be83e3b63ed83b943a2e8deR234-R244)`)