### PR TITLE
Feat/Improve Select2 Widgets

### DIFF
--- a/static/js/select2_custom_es.js
+++ b/static/js/select2_custom_es.js
@@ -1,0 +1,41 @@
+(function () {
+  if (jQuery && jQuery.fn && jQuery.fn.select2 && jQuery.fn.select2.amd) {
+    var e = jQuery.fn.select2.amd;
+    e.define("select2/i18n/es", [], function () {
+      // Sobrescribimos las traducciones por defecto de Select2 para español
+      return {
+        errorLoading: function () {
+          return "No se pudieron cargar los resultados";
+        },
+        inputTooLong: function (e) {
+          var t = e.input.length - e.maximum,
+            n = "Por favor, elimine " + t + " car";
+          return (n += 1 == t ? "ácter" : "acteres");
+        },
+        // --- INICIO: ESTA ES LA TRADUCCIÓN QUE QUEREMOS CAMBIAR ---
+        inputTooShort: function (e) {
+          var t = e.minimum - e.input.length,
+            n = "Por favor, ingrese " + t + " o más car";
+          return (n += 1 == t ? "acteres" : "acteres");
+        },
+        // --- FIN: ESTA ES LA TRADUCCIÓN QUE QUEREMOS CAMBIAR ---
+        loadingMore: function () {
+          return "Cargando más resultados…";
+        },
+        maximumSelected: function (e) {
+          var t = "Sólo puede seleccionar " + e.maximum + " elemento";
+          return 1 != e.maximum && (t += "s"), t;
+        },
+        noResults: function () {
+          return "No se encontraron resultados";
+        },
+        searching: function () {
+          return "Buscando…";
+        },
+        removeAllItems: function () {
+          return "Eliminar todos los elementos";
+        },
+      };
+    });
+  }
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -113,7 +113,9 @@
     <script src="{% static 'js/scripts.js' %}"></script>
     <!-- Select2 JS -->
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/i18n/es.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/i18n/es.js"></script> -->
+    <!-- Cargar nuestras traducciones personalizadas para Select2 -->
+    <script src="{% static 'js/select2_custom_es.js' %}"></script>
     <script>
         $(document).ready(function() {
             // Este selector es genérico y activará cualquier campo preparado para AJAX


### PR DESCRIPTION
## PR Description: Feat/Improve Select2 Widgets

This pull request introduces a custom Spanish translation file for the Select2 library and updates the HTML template to use this custom file instead of the default CDN-provided translation. The custom file allows for more control over the translation strings, including a specific change to the "inputTooShort" message.

### Custom Spanish Translations for Select2:
* [`static/js/select2_custom_es.js`](diffhunk://#diff-c8ca9e2ed537caa2a4ca3d4a32ec74e9399207fb8863e51f5c2eeee04a6e5276R1-R41): Added a custom JavaScript file that overrides the default Select2 Spanish translations. This includes a modification to the "inputTooShort" message to provide a more user-friendly prompt.

### Template Update:
* [`templates/base.html`](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eL116-R118): Updated the HTML template to load the custom Spanish translation file (`select2_custom_es.js`) from the static directory instead of the default CDN-provided translation file.